### PR TITLE
use raw scalar for open

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -36,6 +36,7 @@ makemaker_args
 # tests
 tests           't/*.t';
 test_requires   'Test::More' => 0;
+test_requires   'Devel::Refcount' => 0;
 
 # create Makefile
 WriteAll;

--- a/lib/Win32/LongPath.pm
+++ b/lib/Win32/LongPath.pm
@@ -469,8 +469,10 @@ else
 
 if (!defined $nFD)
   { return; }
-if (!CORE::open ($$oFH, "$sMode&=$nFD"))
+my $fh;
+if (!CORE::open ($fh, "$sMode&=$nFD"))
   { return; }
+$$oFH = $fh;
 if ($sLayer ne '')
   {
   if (!binmode $$oFH, $sLayer)

--- a/t/LongPath.t
+++ b/t/LongPath.t
@@ -7,6 +7,7 @@
 #	Disable utimeL testing on Cygwin.
 ##########
 
+use Devel::Refcount qw( refcount );
 use Fcntl ':mode';
 use File::Spec::Functions;
 use Test::More;
@@ -285,7 +286,7 @@ sub CreateFile
 # o verify line count
 ###########
 
-plan tests => 5;
+plan tests => 6;
 my $oF1;
 $hFiles {newfile}->{path} = catfile ($sSubdir, $hFiles {newfile}->{name});
 if (!ok (openL (\$oF1, '>', $hFiles {newfile}->{path}), 'openL (>newfile)'))
@@ -324,6 +325,9 @@ else
     { }
   if (!eof $oF1)
     { test_exit (0, 'stopped before EOF!'); }
+  my $refcount = refcount ($oF1);
+  is ($refcount, 1, 'refcount')
+    or test_exit (0, "1 != $refcount");
   close $oF1;
   }
 ok ($nIndex == 3, 'linecount == 3?')


### PR DESCRIPTION
Perl 5.22 introduced a bug when opening file handles into a scalar ref.
An extra reference to the handle is created preventing the handle from
being closed when the variable goes out of scope.  For scripts that open
a large number of files, this can exhaust the OS limit on open file
descriptors.  Work around the issue by opening into a plain scalar and
assigning to the destination following the open.

Fixes #3
