### PR TITLE
fix test failure from Perl 5.38 onwards

### DIFF
--- a/t/LongPath.t
+++ b/t/LongPath.t
@@ -545,6 +545,9 @@ foreach my $oOpen (@oOpens)
         {
         ok (!$oOpen->{read} || $oOpen->{trunc},
           $bSys ? 'sysread ()' : 'text read');
+        # clear the error or future calls will fail
+        # (readline stopped clearing the error since perl commit 80c1f1e)
+        $oF1->clearerr if !$oOpen->{read} || $oOpen->{trunc};
         }
       else
         {


### PR DESCRIPTION
This should fix #14. The sequence of read/write on append only files will fail from Perl 5.38 on all platforms. I don't know if this was documented, but I verified it on Linux too.